### PR TITLE
fixing the relative path detection for qlqueries

### DIFF
--- a/argus_components/common/config.py
+++ b/argus_components/common/config.py
@@ -25,7 +25,7 @@ import os
 
 LOCAL_FOLDER : pathlib.Path = pathlib.Path('/tmp')
 CODEQL_BIN : pathlib.Path = pathlib.Path('~/codeql_home/codeql/codeql')
-QUERY_PATH : pathlib.Path = pathlib.Path(os.getcwd()) / "qlqueries"
+QUERY_PATH : pathlib.Path = pathlib.Path(os.path.dirname(__file__)) / "../../qlqueries"
 ENABLE_LOW_PRIORITY_REPORTS : bool = True
 RESULTS_FOLDER : pathlib.Path = pathlib.Path("/results")
 


### PR DESCRIPTION
Hello, @R3x!

Here are another small fix. 

When using Argus locally (not docker), and running **argus.py** from different working directory, eg `cd / && python /home/user/Argus/argus.py ...` the script will fail to find the location of the **qlqueries** folder. 

To fix that we need to start looking for **qlqueries** folder relative to **config.py** file, not current working directory.  

This change does NOT affect the docker run. I tested by running docker tests. 